### PR TITLE
投稿失敗時の処理を追加し、tokenの扱いをより適切にした

### DIFF
--- a/index.html
+++ b/index.html
@@ -213,6 +213,7 @@
         const app_info = {
             "client_id":"fAPnpTwYhXj8DpeGxY-brBtnM43Yw-0Tzjvi6iw1DBs",
             "client_secret":"CTufqdnM6j3Cxx3FZPIH8O4Vnqg9BIJohvZybCbfBqo",
+            "redirect_uri":"https://kurajo.ivory.ne.jp/rakugaki_pao/index.html",
             "vapid_key":"BCMA3J7dkSc4NYWbGKgzgqqHIkkwTKJmJkWZRfkxPI9Poh4msHmnb0LGnUMxM5oVTX4-3qF5WElseplSwxmKkYk="
         };
         const hostName = "mistodon.cloud"; // 霧鯖だけですわ
@@ -528,7 +529,7 @@
                         headers: {
                             'Content-Type': 'application/x-www-form-urlencoded'
                         },
-                        body: `code=${code}&client_id=${app_info.client_id}&client_secret=${app_info.client_secret}&grant_type=authorization_code&redirect_uri=https://kurajo.ivory.ne.jp/rakugaki_pao/index.html&scope=write%20read`
+                        body: `code=${code}&client_id=${app_info.client_id}&client_secret=${app_info.client_secret}&grant_type=authorization_code&redirect_uri=${app_info.redirect_uri}&scope=write%20read`
                     }
                 )
                 .then(response => response.json())
@@ -541,7 +542,7 @@
         }
 
         function getTokenRedirect() {
-            document.location = `${serverUrl}/oauth/authorize?response_type=code&redirect_uri=https://kurajo.ivory.ne.jp/rakugaki_pao/index.html&scope=write%20read&client_id=${app_info.client_id}`;
+            document.location = `${serverUrl}/oauth/authorize?response_type=code&redirect_uri=${app_info.redirect_uri}&scope=write%20read&client_id=${app_info.client_id}`;
         }
 
         function dataURLToBlob(dataURL) {

--- a/index.html
+++ b/index.html
@@ -211,10 +211,9 @@
     </div>
     <script>
         const app_info = {
-            "client_id":"fAPnpTwYhXj8DpeGxY-brBtnM43Yw-0Tzjvi6iw1DBs",
-            "client_secret":"CTufqdnM6j3Cxx3FZPIH8O4Vnqg9BIJohvZybCbfBqo",
+            "client_id":"hckNv2TV74MVO9e-vc2oRvOGDH211pbnLEvH3Z5_8Ww",
+            "client_secret":"zCiw-bHy2VF9NEUXpNIzQUxB8TqgpB1ccwz7lrTcF7s",
             "redirect_uri":"https://kurajo.ivory.ne.jp/rakugaki_pao/index.html",
-            "vapid_key":"BCMA3J7dkSc4NYWbGKgzgqqHIkkwTKJmJkWZRfkxPI9Poh4msHmnb0LGnUMxM5oVTX4-3qF5WElseplSwxmKkYk="
         };
         const hostName = "mistodon.cloud"; // 霧鯖だけですわ
         const serverUrl = "https://" + hostName; 
@@ -235,6 +234,7 @@
         const ctxColor = colorLayer.getContext('2d');
         const localstorageKeyBlack = 'blacklayerlskey';
         const localstorageKeyColor = 'colorlayerlskey';
+        const localstorageKeyAccessToken = 'accesstokenkey';
         const ctxAactiveStroke = activeStrokeLayer.getContext('2d');
         const ctxBg = backgroundLayer.getContext('2d');
         const cursor = document.getElementById('cursor');
@@ -445,6 +445,7 @@
         function restoreLocalstorage() {
             restoreLayeronlocalstorage(localstorageKeyBlack,blackLayer);
             restoreLayeronlocalstorage(localstorageKeyColor,colorLayer);
+            accessToken = window.localStorage.getItem(localstorageKeyAccessToken);
         }
 
         function restoreLayeronlocalstorage(localstoragekey,layer) {
@@ -485,7 +486,14 @@
                         return formData;
                     })()
             })
-            .then(response => response.json())
+            .then(response => { 
+                if (!response.ok) {
+                    accessToken = null;
+                    window.localStorage.removeItem(localstorageKeyAccessToken);
+                    throw "PostError";
+                }
+                return response.json()
+            })
             .then(data => {
                 return fetch(`${serverUrl}/api/v1/statuses`, {
                     method: 'POST',
@@ -501,11 +509,19 @@
             })
             .then(() => {
                 alert('投稿しましたわ！')
-                document.location = currentPageUrl;
+                // document.location = currentPageUrl;
             })
             .catch(error => {
-                console.error('Error:', error);
-                alert('投稿中にエラーが発生しましたの‥‥');
+                if (error == "PostError")
+                {
+                    alert("ポストエラー、トークンが駄目っぽいのでもう一度codeを取り直します。もう一度ポストしてみてね。");
+                    getAuthCodeRedirect();
+                }
+                else
+                {
+                    console.error('Error:', error);
+                    alert('投稿中に良くわからないエラーが発生しましたの‥‥');
+                }
             });
 
         }
@@ -513,36 +529,11 @@
         function postToMastodon() {
             combineCanvas();
             const dataURL = combinedCanvas.toDataURL('image/png');
-
-            if (!code) { 
-                alert(`初回のみ認証が必要ですの。\n[OK]を押すと ${hostName} の認証画面に移動しますので、承認をお願いいたします。その後 rakugaki_pao の画面に戻りますので、もう一度投稿ボタンを押してくださいませ。\n\n次回以降は投稿ボタンを押すだけで投稿できますわ。\n\n認証から時間がたつと、投稿ボタンを押しても投稿されないことがありますの。\nそのときは、投稿ボタン右側のトークン再取得ボタン🔄️を押してから、もう投稿ボタンを押してくださいませ。`);
-                getTokenRedirect();
-                return;
-            }
-
-            if (accessToken) {
-                postImage(dataURL, accessToken);
-            } else {
-                fetch(`${serverUrl}/oauth/token`, 
-                    {
-                        method: 'POST',
-                        headers: {
-                            'Content-Type': 'application/x-www-form-urlencoded'
-                        },
-                        body: `code=${code}&client_id=${app_info.client_id}&client_secret=${app_info.client_secret}&grant_type=authorization_code&redirect_uri=${app_info.redirect_uri}&scope=write%20read`
-                    }
-                )
-                .then(response => response.json())
-                .then(data=>{
-                    accessToken = data.access_token;
-                    postImage(dataURL, accessToken);
-                    return data.access_token;
-                })
-            }
+            postImage(dataURL, accessToken);
         }
 
-        function getTokenRedirect() {
-            document.location = `${serverUrl}/oauth/authorize?response_type=code&redirect_uri=${app_info.redirect_uri}&scope=write%20read&client_id=${app_info.client_id}`;
+        function getAuthCodeRedirect() {
+            document.location = `${serverUrl}/oauth/authorize?response_type=code&redirect_uri=${app_info.redirect_uri}&scope=write&client_id=${app_info.client_id}`;
         }
 
         function dataURLToBlob(dataURL) {
@@ -624,6 +615,12 @@
             updateActiveButton();
             updateToolSize();
             updateToolOpacity();
+        }
+
+        function enablePostButton() {
+            getTokenButton.style.display = 'none';
+            postButton.style.display = '';
+            postButton.style.backgroundColor = '#0E6AE4';
         }
 
         blackLayer.addEventListener('mousedown', startDrawingMouse);
@@ -729,7 +726,7 @@
 
         saveButton.addEventListener('click', saveImage);
         postButton.addEventListener('click', postToMastodon);
-        getTokenButton.addEventListener('click', getTokenRedirect);
+        getTokenButton.addEventListener('click', getAuthCodeRedirect);
 
         copyTextButton.addEventListener('click', () => {
             if (navigator.clipboard) {
@@ -747,30 +744,34 @@
 
 
 
-        if(code){
-            let count = 50;
-            let timeoutId = null;
-            
-            remainingTimeBar.style.visibility = 'visible';
-            getTokenButton.style.display = 'none';
-            postButton.style.display = '';
-            postButton.style.backgroundColor = '#0E6AE4';
-            function countdown() {
-                remainingTimeBar.value = count;
-                
-                
-                if (count < 0) {
-                    clearTimeout(timeoutId);
-                    document.location = currentPageUrl;
-                }
-                //console.log(count);
-                count--;
-            }
-
-            timeoutId = setInterval(countdown, 200);
-            countdown();
+        if (accessToken) {
+            enablePostButton();            
+        } else if(code) {
+            fetch(`${serverUrl}/oauth/token`, 
+                    {
+                        method: 'POST',
+                        headers: {
+                            'Content-Type': 'application/x-www-form-urlencoded'
+                        },
+                        body: `code=${code}&client_id=${app_info.client_id}&client_secret=${app_info.client_secret}&grant_type=authorization_code&redirect_uri=${app_info.redirect_uri}&scope=write`
+                    }
+                )
+                .then(response => {
+                    if (!response.ok) {
+                        alert("トークンエラー、codeが駄目っぽいのでもう一度codeの取り直しをします。");
+                        getAuthCodeRedirect()
+                        throw "TokenError";
+                    }
+                    return response.json()
+                })
+                .then(data=>{
+                    accessToken = data.access_token;
+                    window.localStorage.setItem(localstorageKeyAccessToken, accessToken);
+                    enablePostButton();
+                })
+        } else {
+            getAuthCodeRedirect();
         }
-
     </script>
 </body>
 </html>


### PR DESCRIPTION
OAuthのauthozieコードとOAuthのaccess tokenをどちらもトークンと呼んでいてややこしかったので、OAuthのauthoize codeはコード、OAuthのacces tokenをトークンと呼ぶ事にする。
ここに簡単に説明を記しておく。

## OAuthの基本的なステップ

1. client_idを使いauthoizeしてcodeをもらう（authorize code、redirectでもらう奴、これの期限は10分ほど）
2. 2のcodeを使ってtken APIを叩き、access tokenをもらう（このトークンはmastodonではずっと有効（あんまり良くないが…））
3. 2のaccess tokenを使ってpost

詳細はこの辺を参考。 [What is the OAuth 2.0 Authorization Code Grant Type? - Okta Developer](https://developer.okta.com/blog/2018/04/10/oauth-authorization-code-grant-type)

## これまでの挙動の問題点と修正

基本的に2のaccess tokenはずっと有効なので、一度取得したらこれを使ってpostし続ければ良い。
一方でcodeは10分ほどで使えなくなる。

これまでリロードすると2が消えて1だけ残る状態だったので、毎回2をやり直そうとしてexpireしていた。

今後はリロードでも2が消えないようにし、またこの投稿がエラーの時にはcode取得からやり直す処理を入れた。

localStorageにacces tokenを入れるのはXSSのリスクが高まるので注意するように言われているが、そもそもrakugaki paoは静的なhtmlで外から何か取得して表示もしないので問題無いだろう。

## 直したほうがいいが直してない所

- プログレスバーとか要らなくなったが削除してない
- トークンの取得、というボタンは名前がややこしいので認証、とかにする方がいいかもしれないがしてない
- メッセージがお嬢様ではない

とりあえずこの辺はそっちでやって。